### PR TITLE
Improvment for GAF-image generation

### DIFF
--- a/timeseries_to_gaf.py
+++ b/timeseries_to_gaf.py
@@ -3,6 +3,7 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import ImageGrid
 from pyts.image import GramianAngularField
 import pandas as pd
+import numpy as np
 import os
 from typing import *
 
@@ -23,27 +24,42 @@ def create_gaf(ts) -> Dict[str, Any]:
 
 
 # Create images of the bundle that we pass
-def create_images(X_plots: Any, image_name: str, destination: str, image_matrix: tuple =(2, 2)) -> None:
+def create_images(X_plots: Any, image_name: str, destination: str) -> None:
     """
     :param X_plots:
     :param image_name:
     :param destination:
-    :param image_matrix:
     :return:
     """
-    fig = plt.figure(figsize=[img * 4 for img in image_matrix])
-    grid = ImageGrid(fig,
-                     111,
-                     axes_pad=0,
-                     nrows_ncols=image_matrix,
-                     share_all=True,
-                     )
-    images = X_plots
-    for image, ax in zip(images, grid):
-        ax.set_xticks([])
-        ax.set_yticks([])
-        ax.imshow(image, cmap='rainbow', origin='lower')
+    
+    window_size = np.sqrt(len(X_plots))
+    assert window_size % 1 == 0. and window_size > 1, "Non-square GAF array not supported! (i.e. 2x2, 3x3 etc. is required)"
+    window_size = int(window_size)
+    if window_size > 2:
+        # Figure size like 3x3, 4x4, 5x5 etc.
+        # Get top and bottom tiles
+        top = np.hstack((X_plots[0:window_size]))
+        bot = np.hstack((X_plots[-window_size:]))
+
+        # Get middle tiles horizontally
+        midTmp = []
+        for i in range(window_size - 2):
+            midTmp.append(np.hstack((X_plots[(i + 1)*window_size:(i + 1)*window_size + window_size])))
+
+        # Stack middle tiles vertically
+        for j, val in enumerate(midTmp):
+            if j == 0:
+                mid = val
+            else:
+                mid = np.vstack((mid,val))
+
+        # Final assembly
+        full = np.vstack((top,mid,bot))
+    else:
+        # Simple case for 2x2 
+        top = np.hstack((X_plots[0], X_plots[1]))
+        bot = np.hstack((X_plots[2], X_plots[3]))
+        full = np.vstack((top, bot))
 
     repo = os.path.join('GramianAngularFields/TRAIN', destination)
-    fig.savefig(os.path.join(repo, image_name))
-    plt.close(fig)
+    plt.imsave(os.path.join(repo, image_name + ".png"), full, cmap="rainbow")


### PR DESCRIPTION
Output images are now exactly as big as the calculated data + RGB-channels (i.e. 40x40x3 for code example).
In comparison from before: There are no white border around the image which.
It can now handle generic square-sized data (e.g. 2x2, 3x3, 4x4 etc.)
The script runs significantly faster.